### PR TITLE
Add link support to Portable Text rich-text content

### DIFF
--- a/app/(studio)/schemas/objects/richText.ts
+++ b/app/(studio)/schemas/objects/richText.ts
@@ -19,7 +19,25 @@ const RichText = defineField({
             component: HighlightRender,
           },
         ],
-        annotations: [],
+        annotations: [
+          {
+            name: 'link',
+            type: 'object',
+            title: 'Länk',
+            fields: [
+              {
+                name: 'href',
+                type: 'url',
+                title: 'URL',
+                validation: (R) =>
+                  R.required().uri({
+                    scheme: ['http', 'https', 'mailto', 'tel'],
+                    allowRelative: true,
+                  }),
+              },
+            ],
+          },
+        ],
       },
     },
   ],

--- a/src/lib/serializers.tsx
+++ b/src/lib/serializers.tsx
@@ -5,6 +5,22 @@ const serializers: Partial<PortableTextReactComponents> = {
     highlight: ({ children }) => (
       <span className="text-what-red-01">{children}</span>
     ),
+    link: ({ value, children }) => {
+      const href: string = value?.href ?? '';
+      const isExternal = /^https?:\/\//.test(href);
+      return (
+        <a
+          href={href}
+          className="underline hover:text-what-red-01 focus:text-what-red-01 cursor-pointer"
+          {...(isExternal && {
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          })}
+        >
+          {children}
+        </a>
+      );
+    },
   },
 };
 


### PR DESCRIPTION
## Summary

Customer-requested feature: editors can now apply links to text inside rich-text content (project descriptions and the studio page). Closes #58.

## Changes

- **`app/(studio)/schemas/objects/richText.ts`** — adds a `link` annotation under `marks.annotations` with a single \`href\` URL field. Validation accepts \`http\`, \`https\`, \`mailto\`, \`tel\`, and relative paths.
- **`src/lib/serializers.tsx`** — adds a \`link\` mark renderer that auto-detects external links (\`https?://\`) and opens them in a new tab with \`rel=\"noopener noreferrer\"\`. Internal / \`mailto:\` / \`tel:\` / relative URLs stay in the same tab (correct default for those schemes).

## Design notes

- **No \"open in new tab\" toggle** for editors — derived from the URL pattern at render time. One fewer field to misconfigure.
- **No Sanity references for internal links** — plain string \`href\` is sufficient for a brochure site this size.
- **Styling reuses an existing pattern** — \`underline hover:text-what-red-01 focus:text-what-red-01 cursor-pointer\` matches the project-page \"tillbaka\" button. Not a new pattern.
- **\`focus:\` state added** for keyboard accessibility.
- **Schema change is purely additive** — existing rich-text content has no \`link\` marks; nothing to migrate.

## Test plan

- [x] \`npm run build\` clean — all 59 project pages + 4 routes generated, no TS errors
- [x] Author-side: link UI appears in Studio rich-text editor and accepts URLs
- [x] Public-side: linked text renders with underline + red hover/focus, external links open in new tab, internal/mailto/tel stay in same tab
- [ ] Verify on Cloudflare Pages preview deploy after push

## Astro migration follow-up

The schema change is framework-agnostic and survives the Astro migration unchanged. Issue #56 (Astro migration: Component port, pages, Portable Text) covers re-porting the renderer to \`astro-portabletext\` syntax — same logic, different framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)