### PR TITLE
Fix project page crash when project has no images

### DIFF
--- a/pages/projekt/[project].tsx
+++ b/pages/projekt/[project].tsx
@@ -1,4 +1,3 @@
-import { SanityImageSource } from '@sanity/image-url/lib/types/types';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -17,17 +16,16 @@ type Props = {
 };
 
 const ProjectPage: FC<Props> = ({ project, settings }) => {
-  const images = project.images.slice(1).map((obj) => obj.asset);
+  const images = (project.images ?? []).slice(1).map((obj) => obj.asset);
   const router = useRouter();
-  const ogImageSrc = imageBuilder(project.mainImage as SanityImageSource)
-    .width(1200)
-    .height(630)
-    .url();
+  const ogImageSrc = project.mainImage
+    ? imageBuilder(project.mainImage).width(1200).height(630).url()
+    : undefined;
   return (
     <Page settings={settings} className="items-center">
       <Head>
         <title>{project.title}</title>
-        <meta property="og:image" content={ogImageSrc} />
+        {ogImageSrc && <meta property="og:image" content={ogImageSrc} />}
         <meta property="og:title" content={project.title} />
         <meta property="og:type" content="website" />
       </Head>

--- a/src/components/organisms/ProjectHeader.tsx
+++ b/src/components/organisms/ProjectHeader.tsx
@@ -15,7 +15,8 @@ const Block: FC<{ children?: ReactNode }> = ({ children }) => (
 );
 
 const ProjectHeader: FC<Props> = ({ project }) => {
-  const { title, images, textBody } = project;
+  const { title, textBody } = project;
+  const images = project.images ?? [];
   const mainImage = images[0]?.asset;
   return (
     <div className="mb-10 lg:mb-20 space-y-10 lg:space-y-20 flex flex-col">

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export type Project = {
   mainImage?: SanityImageAssetDocument;
   textBody: PortableTextBlock[];
   description: string;
-  images: { asset: SanityImageAssetDocument }[];
+  images?: { asset: SanityImageAssetDocument }[];
   categories: Category[];
   credits?: string;
   _id: string;


### PR DESCRIPTION
## Summary

Support text-only projects. Closes #61.

A project with no images set in Sanity crashed the rendered page because \`Project.images\` was typed as required while Sanity returns \`undefined\` for unset fields. Three crash points fixed in three files.

## Changes

- **\`src/types.ts\`** — mark \`Project.images\` as optional (\`images?:\`) to reflect Sanity's actual behavior.
- **\`pages/projekt/[project].tsx\`** — default \`project.images\` to \`[]\` before slicing; compute \`ogImageSrc\` only when \`mainImage\` exists; render \`<meta property=\"og:image\">\` conditionally so we never inject a broken URL. Drop the misleading \`as SanityImageSource\` cast that was hiding the optionality.
- **\`src/components/organisms/ProjectHeader.tsx\`** — default \`project.images\` to \`[]\` at the top of the component; existing \`images[0]?.asset\` and \`{mainImage && ...}\` guards already handle the empty case.

## Why this approach (vs GROQ \`coalesce\`)

Making the type honest catches every read of \`project.images\` at compile time, including future ones. A GROQ \`coalesce(images, [])\` would fix this one query but leaves the same bug class lurking elsewhere. TypeScript's \`strict\` mode confirmed these two consumers are the only call sites that needed updating.

## Test plan

- [x] \`npm run build\` clean — all 59 project pages + 4 routes generated, no TS errors
- [ ] Manual: edit a project in Sanity, clear all images + \`mainImage\`, save → page renders header text + info box without crashing, no hero image, no \`og:image\` meta tag
- [ ] Verify on Cloudflare Pages preview deploy

## Out of scope

- The \`mainImage\` vs \`images[0]\` content-model conflation flagged in \`docs/codebase-review.md\`. Separate concern; this fix makes the current model not crash but doesn't restructure it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)